### PR TITLE
Add Vertex Width Change support for  Calligraphic effects

### DIFF
--- a/examples/vertexWidth/README.md
+++ b/examples/vertexWidth/README.md
@@ -1,0 +1,115 @@
+# Variable Width Path Example
+
+This example demonstrates how to create embroidery paths with variable width using p5.embroider.
+
+## Three Ways to Specify Width
+
+### 1. Using `vertex(x, y, width)`
+The z-coordinate parameter of `vertex()` can be used to specify the width at that point:
+
+```javascript
+beginShape();
+vertex(10, 10, 1);    // Start thin (width = 1mm)
+vertex(30, 10, 5);    // Get thicker (width = 5mm)
+vertex(50, 10, 8);    // Maximum thickness (width = 8mm)
+vertex(70, 10, 5);    // Get thinner (width = 5mm)
+vertex(90, 10, 1);    // End thin (width = 1mm)
+endShape();
+```
+
+### 2. Using `vertexWidth(width)` before `vertex(x, y)`
+Set the width for the next vertex call:
+
+```javascript
+beginShape();
+vertexWidth(2);
+vertex(10, 20);       // This vertex will have width = 2mm
+vertexWidth(6);
+vertex(30, 25);       // This vertex will have width = 6mm
+vertexWidth(2);
+vertex(50, 20);       // This vertex will have width = 2mm
+endShape();
+```
+
+### 3. Using `vertexWidth(x, y, width)`
+Combined function that creates a vertex with specified width:
+
+```javascript
+beginShape();
+vertexWidth(10, 30, 2);   // Creates vertex at (10, 30) with width 2mm
+vertexWidth(30, 35, 6);   // Creates vertex at (30, 35) with width 6mm
+vertexWidth(50, 30, 2);   // Creates vertex at (50, 30) with width 2mm
+endShape();
+```
+
+## Width Interpolation
+
+The width is automatically interpolated between vertices:
+- For straight line segments, width is linearly interpolated
+- For bezier curves, width is interpolated along the curve
+- For quadratic and curve vertices, width follows the curve shape
+
+## Stroke Modes
+
+Variable width works with following stroke modes:
+
+- `zigzag` - Zigzag pattern with varying amplitude
+
+
+## Use Cases
+
+### Calligraphic Effects
+Create brush-like strokes that vary in thickness:
+
+```javascript
+beginShape();
+vertex(x1, y1, 2);    // Thin upstroke
+vertex(x2, y2, 8);    // Thick downstroke
+vertex(x3, y3, 2);    // Thin upstroke
+endShape();
+```
+
+### Organic Shapes
+Create natural-looking lines that respond to movement:
+
+```javascript
+for (let i = 0; i < points.length; i++) {
+  let speed = calculateSpeed(i);
+  let width = map(speed, 0, maxSpeed, 8, 2);  // Faster = thinner
+  vertex(points[i].x, points[i].y, width);
+}
+```
+
+### Tapered Lines
+Create lines that fade in and out:
+
+```javascript
+beginShape();
+vertex(x1, y1, 0.5);  // Very thin start
+vertex(x2, y2, 5);    // Thick middle
+vertex(x3, y3, 0.5);  // Very thin end
+endShape();
+```
+
+## Technical Details
+
+- Width values are in millimeters (mm)
+- Default width is taken from `strokeWeight()` if not specified
+- Minimum recommended width: 0.5mm
+- Maximum recommended width: 10mm (depends on fabric and thread)
+- Width affects the offset distance for zigzag and other decorative stitches
+
+## Keyboard Shortcuts
+
+- `d` - Export as DST file
+- `g` - Export as G-code
+- `s` - Export as SVG
+- `r` - Redraw
+
+## Notes
+
+- Variable width is particularly effective with `zigzag` stroke mode
+- For very thin widths (< 1mm), consider using `straight` stroke mode
+- Width changes should be gradual for best embroidery results
+- Extreme width changes may cause thread tension issues on actual machines
+

--- a/examples/vertexWidth/index.html
+++ b/examples/vertexWidth/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.1/p5.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/p5.js/1.11.1/addons/p5.sound.min.js"></script>
+    <link rel="stylesheet" type="text/css" href="style.css">
+    <meta charset="utf-8" />
+    <script src="../../lib/p5.embroider.js"></script>
+  </head>
+  <body>
+    <main>
+    </main>
+    <script src="sketch.js"></script>
+  </body>
+</html>
+

--- a/examples/vertexWidth/sketch.js
+++ b/examples/vertexWidth/sketch.js
@@ -1,0 +1,171 @@
+/**
+ * Variable Width Path Example
+ * 
+ * This example demonstrates three ways to create variable-width embroidery paths:
+ * 1. Using vertex(x, y, width) - z-coordinate as width
+ * 2. Using vertexWidth(width) before vertex(x, y)
+ * 3. Using vertexWidth(x, y, width) - combined function
+ */
+
+let drawMode = "realistic";
+
+function setup() {
+  createCanvas(mmToPixel(120), mmToPixel(150));
+  
+  // UI Buttons
+  let drawModeStitchButton = createButton("Draw Mode: Stitch");
+  drawModeStitchButton.mousePressed(() => {
+    drawMode = "stitch";
+    redraw();
+  });
+
+  let drawModeRealisticButton = createButton("Draw Mode: Realistic");
+  drawModeRealisticButton.mousePressed(() => {
+    drawMode = "realistic";
+    redraw();
+  });
+
+  let drawModeP5Button = createButton("Draw Mode: p5");
+  drawModeP5Button.mousePressed(() => {
+    drawMode = "p5";
+    redraw();
+  });
+
+  let exportDstButton = createButton("Export DST");
+  exportDstButton.mousePressed(() => {
+    exportEmbroidery("variable-width.dst");
+  });
+  exportDstButton.position(0, height + 30);
+
+  let exportGcodeButton = createButton("Export Gcode");
+  exportGcodeButton.mousePressed(() => {
+    exportGcode("variable-width.gcode");
+  });
+  exportGcodeButton.position(90, height + 30);
+
+  let exportSVGButton = createButton("Export SVG");
+  exportSVGButton.mousePressed(() => {
+    exportSVG("variable-width.svg");
+  });
+  exportSVGButton.position(200, height + 30);
+
+  noLoop();
+}
+
+function draw() {
+  background("#FFF5DC");
+  translate(mmToPixel(10), mmToPixel(10));
+
+  setDrawMode(drawMode);
+  beginRecord(this);
+  //strokeWeight(1);
+  setStitch(0.1, 0.2, 0);
+  // Example 1: Using vertex(x, y, width) - Tapered stroke
+  stroke(255, 0, 100);
+  noFill();
+  setStrokeMode("zigzag");
+  
+  beginShape();
+  vertex(10, 10, 1);    // Start thin
+  vertex(30, 10, 5);    // Get thicker
+  vertex(50, 10, 8);    // Maximum thickness
+  vertex(70, 10, 5);    // Get thinner
+  vertex(90, 10, 1);    // End thin
+  endShape();
+  trimThread();
+
+  // Example 2: Using vertexWidth(w) - Wave pattern
+  stroke(0, 150, 255);
+  setStrokeMode("zigzag");
+  
+  beginShape();
+  for (let i = 0; i <= 10; i++) {
+    let x = 10 + i * 8;
+    let y = 30 + sin(i * 0.8) * 5;
+    let width = 2 + sin(i * 0.8) * 4; // Width varies with wave
+    vertexWidth(width);
+    vertex(x, y);
+  }
+  endShape();
+  trimThread();
+
+  // Example 3: Using vertexWidth(x, y, w) - Calligraphic effect
+  stroke(100, 50, 200);
+  setStrokeMode("zigzag");
+  
+  beginShape();
+  vertexWidth(20, 50, 2);
+  vertexWidth(30, 55, 6);
+  vertexWidth(40, 58, 8);
+  vertexWidth(50, 58, 8);
+  vertexWidth(60, 55, 6);
+  vertexWidth(70, 50, 2);
+  vertexWidth(80, 50, 2);
+  vertexWidth(90, 55, 6);
+  endShape();
+  trimThread();
+
+  // Example 4: Bezier curve with variable width
+  stroke(255, 150, 0);
+  setStrokeMode("zigzag");
+  
+  beginShape();
+  vertex(10, 70, 2);
+  vertexWidth(4);
+  bezierVertex(30, 65, 50, 85, 70, 70);
+  vertexWidth(2);
+  bezierVertex(75, 68, 80, 65, 90, 70);
+  endShape();
+  trimThread();
+
+  // Example 5: Spiral with increasing width
+  stroke(0, 200, 100);
+  setStrokeMode("zigzag");
+  
+  let centerX = 50;
+  let centerY = 115;
+  beginShape();
+  for (let angle = 0; angle < TWO_PI * 2; angle += 0.2) {
+    let radius = angle * 2;
+    let x = centerX + cos(angle) * radius;
+    let y = centerY + sin(angle) * radius;
+    let width = 1 + (angle / (TWO_PI * 2)) * 4; // Width increases with spiral
+    vertex(x, y, width);
+  }
+  endShape();
+  trimThread();
+
+  endRecord();
+  
+  // Draw labels in p5 mode (not embroidered)
+  if (drawMode === "p5" || drawMode === "realistic") {
+    push();
+    fill(0);
+    noStroke();
+    textSize(mmToPixel(2));
+    text("1. vertex(x,y,w)", mmToPixel(10), mmToPixel(8));
+    text("2. vertexWidth(w)", mmToPixel(10), mmToPixel(28));
+    text("3. vertexWidth(x,y,w)", mmToPixel(10), mmToPixel(48));
+    text("4. Bezier + width", mmToPixel(10), mmToPixel(68));
+    text("5. Spiral", mmToPixel(10), mmToPixel(88));
+    pop();
+  }
+}
+
+function keyPressed() {
+  switch (key) {
+    case "d":
+      exportEmbroidery("variable-width.dst");
+      break;
+    case "g":
+      exportGcode("variable-width.gcode");
+      break;
+    case "s":
+      exportSVG("variable-width.svg");
+      break;
+    case "r":
+      redraw();
+      break;
+  }
+}
+

--- a/examples/vertexWidth/style.css
+++ b/examples/vertexWidth/style.css
@@ -1,0 +1,8 @@
+html, body {
+  margin: 0;
+  padding: 0;
+}
+canvas {
+  display: block;
+}
+

--- a/lib/p5.embroider.js
+++ b/lib/p5.embroider.js
@@ -3775,6 +3775,7 @@
     let _contours = [];
     let _currentContour = [];
     let _isContour = false;
+    let _nextVertexWidth = null; // Width for the next vertex (set by vertexWidth())
 
     let _strokeThreadIndex = 0;
     let _fillThreadIndex = 0;
@@ -4318,8 +4319,31 @@
     function overrideVertexFunction() {
       _originalVertexFunc = window.vertex;
 
-      window.vertex = function (x, y, moveTo, u, v) {
+      window.vertex = function (x, y, z_or_moveTo, u, v) {
         if (_recording) {
+          // Determine if third parameter is z (width) or moveTo
+          let width = null;
+          let moveTo = false;
+          
+          if (typeof z_or_moveTo === 'number') {
+            // Third parameter is z-coordinate (width)
+            width = z_or_moveTo;
+          } else if (z_or_moveTo === true || z_or_moveTo === false) {
+            // Third parameter is moveTo boolean
+            moveTo = z_or_moveTo;
+          }
+          
+          // If width not provided via z-coordinate, check if set by vertexWidth()
+          if (width === null && _nextVertexWidth !== null) {
+            width = _nextVertexWidth;
+            _nextVertexWidth = null; // Reset after use
+          }
+          
+          // If still no width, use default strokeWeight
+          if (width === null) {
+            width = _strokeSettings.strokeWeight;
+          }
+          
           // Apply current transformation to the vertex coordinates
           const transformedPoint = transformPoint({ x, y }, _currentTransform.matrix);
 
@@ -4327,6 +4351,7 @@
           const vert = {
             x: transformedPoint.x,
             y: transformedPoint.y,
+            width: width,
             u: u || 0,
             v: v || 0,
             isVert: true,
@@ -4342,17 +4367,42 @@
 
           // Add to appropriate container based on contour state
           if (_isContour) {
-            _currentContour.push({ x: transformedPoint.x, y: transformedPoint.y });
-            if (_DEBUG) console.log("Added to contour (transformed):", { x: transformedPoint.x, y: transformedPoint.y });
+            _currentContour.push({ 
+              x: transformedPoint.x, 
+              y: transformedPoint.y,
+              width: width 
+            });
+            if (_DEBUG) console.log("Added to contour (transformed):", { x: transformedPoint.x, y: transformedPoint.y, width: width });
           } else {
             _vertices.push(vert);
             if (_DEBUG) console.log("Added to vertices (transformed):", vert);
           }
         } else {
-          let args = [mmToPixel$1(x), mmToPixel$1(y), moveTo, u, v];
+          let args = [mmToPixel$1(x), mmToPixel$1(y), z_or_moveTo, u, v];
           _originalVertexFunc.apply(this, args);
         }
       };
+    }
+
+    /**
+     * Set width for the next vertex or create a vertex with width
+     * Can be called in three ways:
+     * 1. vertexWidth(w) - sets width for next vertex() call
+     * 2. vertexWidth(x, y, w) - creates a vertex at (x,y) with width w
+     * @param {number} arg1 - Either width (if only one arg) or x-coordinate (if three args)
+     * @param {number} arg2 - y-coordinate (only if three args)
+     * @param {number} arg3 - width (only if three args)
+     */
+    function vertexWidth(arg1, arg2, arg3) {
+      if (arguments.length === 1) {
+        // vertexWidth(w) - set width for next vertex
+        _nextVertexWidth = arg1;
+      } else if (arguments.length === 3) {
+        // vertexWidth(x, y, w) - create vertex with width
+        window.vertex(arg1, arg2, arg3);
+      } else {
+        console.warn("vertexWidth() expects 1 or 3 arguments");
+      }
     }
 
     /**
@@ -4387,6 +4437,14 @@
           }
           const x1 = lastVertex.x;
           const y1 = lastVertex.y;
+          const startWidth = lastVertex.width || _strokeSettings.strokeWeight;
+          
+          // Determine end width
+          let endWidth = startWidth;
+          if (_nextVertexWidth !== null) {
+            endWidth = _nextVertexWidth;
+            _nextVertexWidth = null; // Reset after use
+          }
 
           // Generate bezier curve points using transformed control points
           const bezierPoints = generateBezierPoints(x1, y1, cp1.x, cp1.y, cp2.x, cp2.y, endPoint.x, endPoint.y);
@@ -4394,13 +4452,20 @@
           // Add all points except the first one (which is the last vertex)
           for (let i = 1; i < bezierPoints.length; i++) {
             const point = bezierPoints[i];
+            const t = i / (bezierPoints.length - 1);
+            const interpolatedWidth = startWidth + (endWidth - startWidth) * t;
 
             if (_isContour) {
-              _currentContour.push({ x: point.x, y: point.y });
+              _currentContour.push({ 
+                x: point.x, 
+                y: point.y,
+                width: interpolatedWidth 
+              });
             } else {
               const vert = {
                 x: point.x,
                 y: point.y,
+                width: interpolatedWidth,
                 u: 0,
                 v: 0,
                 isVert: true,
@@ -4463,6 +4528,14 @@
           }
           const x1 = lastVertex.x;
           const y1 = lastVertex.y;
+          const startWidth = lastVertex.width || _strokeSettings.strokeWeight;
+          
+          // Determine end width
+          let endWidth = startWidth;
+          if (_nextVertexWidth !== null) {
+            endWidth = _nextVertexWidth;
+            _nextVertexWidth = null; // Reset after use
+          }
 
           // Generate quadratic bezier curve points using transformed control points
           const quadraticPoints = generateQuadraticPoints(x1, y1, controlPoint.x, controlPoint.y, endPoint.x, endPoint.y);
@@ -4470,13 +4543,20 @@
           // Add all points except the first one (which is the last vertex)
           for (let i = 1; i < quadraticPoints.length; i++) {
             const point = quadraticPoints[i];
+            const t = i / (quadraticPoints.length - 1);
+            const interpolatedWidth = startWidth + (endWidth - startWidth) * t;
 
             if (_isContour) {
-              _currentContour.push({ x: point.x, y: point.y });
+              _currentContour.push({ 
+                x: point.x, 
+                y: point.y,
+                width: interpolatedWidth 
+              });
             } else {
               const vert = {
                 x: point.x,
                 y: point.y,
+                width: interpolatedWidth,
                 u: 0,
                 v: 0,
                 isVert: true,
@@ -4518,9 +4598,20 @@
         if (_recording) {
           // Apply current transformation to the curve vertex
           const transformedPoint = transformPoint({ x, y }, _currentTransform.matrix);
+          
+          // Determine width for this curve vertex
+          let width = _strokeSettings.strokeWeight;
+          if (_nextVertexWidth !== null) {
+            width = _nextVertexWidth;
+            _nextVertexWidth = null; // Reset after use
+          }
 
           // Add to contour vertices for curve calculation using transformed coordinates
-          _contourVertices.push({ x: transformedPoint.x, y: transformedPoint.y });
+          _contourVertices.push({ 
+            x: transformedPoint.x, 
+            y: transformedPoint.y,
+            width: width 
+          });
 
           // For curve vertices, we need at least 4 points to generate a curve segment
           if (_contourVertices.length >= 4) {
@@ -4533,6 +4624,10 @@
             // Generate curve points for this segment
             const curvePoints = generateCurvePoints(p0.x, p0.y, p1.x, p1.y, p2.x, p2.y, p3.x, p3.y);
 
+            // Interpolate width from p1 to p2 (the actual curve segment)
+            const startWidth = p1.width || _strokeSettings.strokeWeight;
+            const endWidth = p2.width || _strokeSettings.strokeWeight;
+
             // If this is the first curve segment, add all points
             // Otherwise, add all points except the first (to avoid duplication)
             let startIdx;
@@ -4544,13 +4639,20 @@
 
             for (let i = startIdx; i < curvePoints.length; i++) {
               const point = curvePoints[i];
+              const t = i / (curvePoints.length - 1);
+              const interpolatedWidth = startWidth + (endWidth - startWidth) * t;
 
               if (_isContour) {
-                _currentContour.push({ x: point.x, y: point.y });
+                _currentContour.push({ 
+                  x: point.x, 
+                  y: point.y,
+                  width: interpolatedWidth 
+                });
               } else {
                 const vert = {
                   x: point.x,
                   y: point.y,
+                  width: interpolatedWidth,
                   u: 0,
                   v: 0,
                   isVert: true,
@@ -4616,11 +4718,17 @@
         return stitches;
       }
 
-      // Extract x,y coordinates from vertex objects for compatibility with path functions
+      // Extract x,y,width coordinates from vertex objects for compatibility with path functions
       const pathPoints = vertices.map((v) => ({
         x: v.x,
         y: v.y,
+        width: v.width !== undefined ? v.width : strokeSettings.strokeWeight,
       }));
+
+      // Check if any vertex has width specified (for variable width paths)
+      const hasVariableWidth = pathPoints.some(p => p.width !== undefined && p.width > 0);
+      const hasStrokeWeight = strokeSettings.strokeWeight > 0;
+      const hasWidth = hasStrokeWeight || hasVariableWidth;
 
       if (_DEBUG) {
         console.log("convertVerticesToStitches input:", {
@@ -4629,16 +4737,18 @@
           strokeWeight: strokeSettings.strokeWeight,
           strokeMode: strokeSettings.strokeMode,
           strokeJoin: strokeSettings.strokeJoin,
+          hasVariableWidth: hasVariableWidth,
+          hasWidth: hasWidth,
         });
       }
 
-      // If we have a stroke weight and multiple vertices, use join-aware stitching
-      if (strokeSettings.strokeWeight > 0 && vertices.length > 2) {
+      // If we have a stroke weight (global or per-vertex) and multiple vertices, use join-aware stitching
+      if (hasWidth && vertices.length > 2) {
         if (_DEBUG) console.log("Using convertPathToStitchesWithJoins");
         return convertPathToStitchesWithJoins(pathPoints, strokeSettings);
       }
       // If we have a stroke weight, use the appropriate path-based function
-      else if (strokeSettings.strokeWeight > 0) {
+      else if (hasWidth) {
         if (_DEBUG) console.log("Using stroke mode:", strokeSettings.strokeMode);
         switch (strokeSettings.strokeMode) {
           case STROKE_MODE.STRAIGHT:
@@ -6012,6 +6122,9 @@
       overrideEndShapeFunction();
       overrideBeginContourFunction();
       overrideEndContourFunction();
+      
+      // Add vertexWidth function to window
+      window.vertexWidth = vertexWidth;
     }
 
     /**
@@ -6388,6 +6501,9 @@
 
       for (let i = 0; i < simplifiedPath.length; i++) {
         const curr = simplifiedPath[i];
+        // Use point's width if available, otherwise use default offset
+        const pointOffset = curr.width !== undefined ? curr.width / 2 : offset;
+        
         let prev, next;
 
         if (isClosedPath) {
@@ -6408,8 +6524,8 @@
           const dy = next.y - curr.y;
           const len = Math.sqrt(dx * dx + dy * dy);
           if (len > 0) {
-            const perpX = (-dy / len) * (isLeft ? offset : -offset);
-            const perpY = (dx / len) * (isLeft ? offset : -offset);
+            const perpX = (-dy / len) * (isLeft ? pointOffset : -pointOffset);
+            const perpY = (dx / len) * (isLeft ? pointOffset : -pointOffset);
             offsetPoint = { x: curr.x + perpX, y: curr.y + perpY };
           } else {
             offsetPoint = { x: curr.x, y: curr.y };
@@ -6420,15 +6536,15 @@
           const dy = curr.y - prev.y;
           const len = Math.sqrt(dx * dx + dy * dy);
           if (len > 0) {
-            const perpX = (-dy / len) * (isLeft ? offset : -offset);
-            const perpY = (dx / len) * (isLeft ? offset : -offset);
+            const perpX = (-dy / len) * (isLeft ? pointOffset : -pointOffset);
+            const perpY = (dx / len) * (isLeft ? pointOffset : -pointOffset);
             offsetPoint = { x: curr.x + perpX, y: curr.y + perpY };
           } else {
             offsetPoint = { x: curr.x, y: curr.y };
           }
         } else {
           // Middle point or closed path vertex - calculate proper join
-          offsetPoint = calculateOffsetCorner(prev, curr, next, offset, isLeft);
+          offsetPoint = calculateOffsetCorner(prev, curr, next, pointOffset, isLeft);
         }
 
         offsetPath.push(offsetPoint);


### PR DESCRIPTION
# Variable Width Path 

This PR adds variable path generation using vertex function. 

## Three Ways to Specify Width

### 1. Using `vertex(x, y, width)`
The z-coordinate parameter of `vertex()` can be used to specify the width at that point:

```javascript
beginShape();
vertex(10, 10, 1);    // Start thin (width = 1mm)
vertex(30, 10, 5);    // Get thicker (width = 5mm)
vertex(50, 10, 8);    // Maximum thickness (width = 8mm)
vertex(70, 10, 5);    // Get thinner (width = 5mm)
vertex(90, 10, 1);    // End thin (width = 1mm)
endShape();
```

### 2. Using `vertexWidth(width)` before `vertex(x, y)`
Set the width for the next vertex call:

```javascript
beginShape();
vertexWidth(2);
vertex(10, 20);       // This vertex will have width = 2mm
vertexWidth(6);
vertex(30, 25);       // This vertex will have width = 6mm
vertexWidth(2);
vertex(50, 20);       // This vertex will have width = 2mm
endShape();
```

### 3. Using `vertexWidth(x, y, width)`
Combined function that creates a vertex with specified width:

```javascript
beginShape();
vertexWidth(10, 30, 2);   // Creates vertex at (10, 30) with width 2mm
vertexWidth(30, 35, 6);   // Creates vertex at (30, 35) with width 6mm
vertexWidth(50, 30, 2);   // Creates vertex at (50, 30) with width 2mm
endShape();
```

## Width Interpolation

The width is automatically interpolated between vertices:
- For straight line segments, width is linearly interpolated
- For bezier curves, width is interpolated along the curve
- For quadratic and curve vertices, width follows the curve shape

## Stroke Modes

Variable width works with following stroke modes:

- `zigzag` - Zigzag pattern with varying amplitude


## Use Cases

### Calligraphic Effects
Create brush-like strokes that vary in thickness:

```javascript
beginShape();
vertex(x1, y1, 2);    // Thin upstroke
vertex(x2, y2, 8);    // Thick downstroke
vertex(x3, y3, 2);    // Thin upstroke
endShape();
```

### Organic Shapes
Create natural-looking lines that respond to movement:

```javascript
for (let i = 0; i < points.length; i++) {
  let speed = calculateSpeed(i);
  let width = map(speed, 0, maxSpeed, 8, 2);  // Faster = thinner
  vertex(points[i].x, points[i].y, width);
}
```

### Tapered Lines
Create lines that fade in and out:

```javascript
beginShape();
vertex(x1, y1, 0.5);  // Very thin start
vertex(x2, y2, 5);    // Thick middle
vertex(x3, y3, 0.5);  // Very thin end
endShape();
```

## Technical Details

- Width values are in millimeters (mm)
- Default width is taken from `strokeWeight()` if not specified
- Minimum recommended width: 0.5mm
- Maximum recommended width: 10mm (depends on fabric and thread)
- Width affects the offset distance for zigzag and other decorative stitches



